### PR TITLE
Fix(example): warning on missing mapbox CSS

### DIFF
--- a/example/src/assets/main.css
+++ b/example/src/assets/main.css
@@ -1,3 +1,4 @@
+@import 'mapbox-gl/dist/mapbox-gl.css';
 @import './base.css';
 
 #app {


### PR DESCRIPTION
- Fixes the warning on missing mapbox CSS. Imports the CSS file at the top of `main.css`.