### PR TITLE
Test(GHA): update workflow

### DIFF
--- a/.github/workflows/build-and-verify.yaml
+++ b/.github/workflows/build-and-verify.yaml
@@ -9,12 +9,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{matrix.node-version}}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node-version}}
       - name: Checking npm version


### PR DESCRIPTION
- Updates `build-and-verify` workflow:
  - bumps `actions/checkout` to v4
  - bumps `actions/setup-node` to v4
  - adds "20.x" to Node.js versions to test