### PR TITLE
Bump version to 0.1.1 with mapbox-gl 3.0.1

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,12 +10,12 @@
 
 以下のコマンドを実行してください。
 ```sh
-npm install https://github.com/codemonger-io/mapbox-geo-circle-layer.git#v0.1.0
+npm install https://github.com/codemonger-io/mapbox-geo-circle-layer.git#v0.1.1
 ```
 
 ### 事前要件
 
-このライブラリはMapbox GL JSバージョン2.xと組み合わせて使用する前提です。
+このライブラリはMapbox GL JSバージョン2.xおよび3.xと組み合わせて使用する前提です。
 
 ### 使い方
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Renders a simple circle on a [Mapbox GL JS](https://docs.mapbox.com/mapbox-gl-js
 
 Please run the following command:
 ```sh
-npm install https://github.com/codemonger-io/mapbox-geo-circle-layer.git#v0.1.0
+npm install https://github.com/codemonger-io/mapbox-geo-circle-layer.git#v0.1.1
 ```
 
 ### Prerequisites
 
-This library is intended to work with Mapbox GL JS v2.x.
+This library is intended to work with Mapbox GL JS v2.x and v3.x.
 
 ### Usage
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,4 @@
+// mapbox-gl v3.x requires TextDecoder which is not provided by jsdom
+// see https://stackoverflow.com/a/68468204
+const { TextDecoder } = require('node:util');
+global.TextDecoder = TextDecoder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapbox-geo-circle-layer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mapbox-geo-circle-layer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/api-documenter": "^7.23.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "@microsoft/api-extractor": "^7.39.1",
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/jest": "^29.5.11",
-        "@types/mapbox-gl": "^2.7.6",
+        "@types/mapbox-gl": "^2.7.19",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "mapbox-gl": "^2.10.0",
+        "mapbox-gl": "^3.0.1",
         "rollup": "^4.9.5",
         "ts-jest": "^29.1.1",
         "tslib": "^2.6.2",
@@ -24,6 +24,9 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "mapbox-gl": "^2.0.0||^3.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1080,12 +1083,6 @@
         "geojson-rewind": "geojson-rewind"
       }
     },
-    "node_modules/@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "dev": true
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -1108,15 +1105,15 @@
       "dev": true
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-      "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
       "dev": true
     },
     "node_modules/@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
       "dev": true
     },
     "node_modules/@mapbox/vector-tile": {
@@ -1629,9 +1626,9 @@
       }
     },
     "node_modules/@types/mapbox-gl": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.6.tgz",
-      "integrity": "sha512-EPIfNO7WApXaFM7DuJBj+kpXmqffqJHMJ3Q9gbV/nNL23XHR0PC5CCDYbAFa4tKErm0xJd9C5kPLF6KvA/cRcA==",
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.19.tgz",
+      "integrity": "sha512-pkRdlhQJNbtwcKJSVC4uuOA6M3OlOObIMhNecqHB991oeaDF5XkjSIRaTE0lh5p4KClptSCxW6MBiREVRHrl2A==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -2034,6 +2031,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cheap-ruler": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-3.0.2.tgz",
+      "integrity": "sha512-02T332h1/HTN6cDSufLP8x4JzDs2+VC+8qZ/N0kWIVPyc2xUkWwWh3B2fJxR7raXkL4Mq7k554mfuM9ofv/vGg==",
+      "dev": true
     },
     "node_modules/ci-info": {
       "version": "3.5.0",
@@ -3684,9 +3687,9 @@
       }
     },
     "node_modules/kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "dev": true
     },
     "node_modules/kleur": {
@@ -3805,31 +3808,32 @@
       }
     },
     "node_modules/mapbox-gl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.10.0.tgz",
-      "integrity": "sha512-ZAlCe55LXlbg60l15okSBs70NQAPLw3yRO3SSJMTB1uU7uj2QQbLCQPy1Ds+3B4wlaa5W3ewv8FNOZPQOoSSPA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.0.1.tgz",
+      "integrity": "sha512-o7C6sAlj6Hkdd4xQVEgQflgJYNYyZOAtYahhIOb9m8chI8umtWcCp8Ie0iGLYJvce1WHRMa3WGzs69ggwuWlDA==",
       "dev": true,
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.1",
-        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.5",
-        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
+        "cheap-ruler": "^3.0.1",
         "csscolorparser": "~1.0.3",
         "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
+        "kdbush": "^4.0.1",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
-        "potpack": "^1.0.2",
+        "potpack": "^2.0.0",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.1.4",
+        "supercluster": "^8.0.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.3"
       }
@@ -4169,9 +4173,9 @@
       }
     },
     "node_modules/potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
       "dev": true
     },
     "node_modules/prelude-ls": {
@@ -4577,12 +4581,12 @@
       }
     },
     "node_modules/supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "dev": true,
       "dependencies": {
-        "kdbush": "^3.0.0"
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/supports-color": {
@@ -5943,12 +5947,6 @@
         "minimist": "^1.2.6"
       }
     },
-    "@mapbox/geojson-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
-      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "dev": true
-    },
     "@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -5968,15 +5966,15 @@
       "dev": true
     },
     "@mapbox/tiny-sdf": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.5.tgz",
-      "integrity": "sha512-OhXt2lS//WpLdkqrzo/KwB7SRD8AiNTFFzuo9n14IBupzIMa67yGItcK7I2W9D8Ghpa4T04Sw9FWsKCJG50Bxw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.6.tgz",
+      "integrity": "sha512-qMqa27TLw+ZQz5Jk+RcwZGH7BQf5G/TrutJhspsca/3SHwmgKQ1iq+d3Jxz5oysPVYTGP6aXxCo5Lk9Er6YBAA==",
       "dev": true
     },
     "@mapbox/unitbezier": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
       "dev": true
     },
     "@mapbox/vector-tile": {
@@ -6363,9 +6361,9 @@
       }
     },
     "@types/mapbox-gl": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.6.tgz",
-      "integrity": "sha512-EPIfNO7WApXaFM7DuJBj+kpXmqffqJHMJ3Q9gbV/nNL23XHR0PC5CCDYbAFa4tKErm0xJd9C5kPLF6KvA/cRcA==",
+      "version": "2.7.19",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.19.tgz",
+      "integrity": "sha512-pkRdlhQJNbtwcKJSVC4uuOA6M3OlOObIMhNecqHB991oeaDF5XkjSIRaTE0lh5p4KClptSCxW6MBiREVRHrl2A==",
       "dev": true,
       "requires": {
         "@types/geojson": "*"
@@ -6665,6 +6663,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
+    },
+    "cheap-ruler": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cheap-ruler/-/cheap-ruler-3.0.2.tgz",
+      "integrity": "sha512-02T332h1/HTN6cDSufLP8x4JzDs2+VC+8qZ/N0kWIVPyc2xUkWwWh3B2fJxR7raXkL4Mq7k554mfuM9ofv/vGg==",
       "dev": true
     },
     "ci-info": {
@@ -7909,9 +7913,9 @@
       }
     },
     "kdbush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
-      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
       "dev": true
     },
     "kleur": {
@@ -8009,31 +8013,32 @@
       }
     },
     "mapbox-gl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-2.10.0.tgz",
-      "integrity": "sha512-ZAlCe55LXlbg60l15okSBs70NQAPLw3yRO3SSJMTB1uU7uj2QQbLCQPy1Ds+3B4wlaa5W3ewv8FNOZPQOoSSPA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-3.0.1.tgz",
+      "integrity": "sha512-o7C6sAlj6Hkdd4xQVEgQflgJYNYyZOAtYahhIOb9m8chI8umtWcCp8Ie0iGLYJvce1WHRMa3WGzs69ggwuWlDA==",
       "dev": true,
       "requires": {
-        "@mapbox/geojson-rewind": "^0.5.1",
-        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/mapbox-gl-supported": "^2.0.1",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^2.0.5",
-        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/tiny-sdf": "^2.0.6",
+        "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
+        "cheap-ruler": "^3.0.1",
         "csscolorparser": "~1.0.3",
         "earcut": "^2.2.4",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.4.3",
         "grid-index": "^1.1.0",
+        "kdbush": "^4.0.1",
         "murmurhash-js": "^1.0.0",
         "pbf": "^3.2.1",
-        "potpack": "^1.0.2",
+        "potpack": "^2.0.0",
         "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "supercluster": "^7.1.4",
+        "supercluster": "^8.0.0",
         "tinyqueue": "^2.0.3",
         "vt-pbf": "^3.1.3"
       }
@@ -8291,9 +8296,9 @@
       }
     },
     "potpack": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
-      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.0.0.tgz",
+      "integrity": "sha512-Q+/tYsFU9r7xoOJ+y/ZTtdVQwTWfzjbiXBDMM/JKUux3+QPP02iUuIoeBQ+Ot6oEDlC+/PGjB/5A3K7KKb7hcw==",
       "dev": true
     },
     "prelude-ls": {
@@ -8598,12 +8603,12 @@
       "dev": true
     },
     "supercluster": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
-      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "dev": true,
       "requires": {
-        "kdbush": "^3.0.0"
+        "kdbush": "^4.0.2"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -29,13 +29,16 @@
     "@microsoft/api-extractor": "^7.39.1",
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/jest": "^29.5.11",
-    "@types/mapbox-gl": "^2.7.6",
+    "@types/mapbox-gl": "^2.7.19",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "mapbox-gl": "^2.10.0",
+    "mapbox-gl": "^3.0.1",
     "rollup": "^4.9.5",
     "ts-jest": "^29.1.1",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"
+  },
+  "peerDependencies": {
+    "mapbox-gl": "^2.0.0||^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-geo-circle-layer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Mapbox layer that renders a circle",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Bumps version to 0.1.1
- Bumps `mapbox-gl` to 3.0.1
- Bumps `@types/mapbox-gl` to 2.7.19

This library seems to work both with `mapbox-gl` v2 and v3.