### PR TITLE
Chore: update example

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "example",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "example",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "mapbox-geo-circle-layer": "github:codemonger-io/mapbox-geo-circle-layer#v0.1.1",
+        "mapbox-geo-circle-layer": "github:codemonger-io/mapbox-geo-circle-layer#v0.2.0",
         "mapbox-gl": "^3.0.1",
         "vue": "^3.3.11"
       },
@@ -2601,8 +2601,8 @@
       }
     },
     "node_modules/mapbox-geo-circle-layer": {
-      "version": "0.1.1",
-      "resolved": "git+ssh://git@github.com/codemonger-io/mapbox-geo-circle-layer.git#aa3d2634d8ec882ea54d5ba032738635f45f6806",
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/codemonger-io/mapbox-geo-circle-layer.git#0b2263812730e66f6259b63d22c4fb1d67480629",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "mapbox-geo-circle-layer": "github:codemonger-io/mapbox-geo-circle-layer#v0.1.1",
+    "mapbox-geo-circle-layer": "github:codemonger-io/mapbox-geo-circle-layer#v0.2.0",
     "mapbox-gl": "^3.0.1",
     "vue": "^3.3.11"
   },

--- a/example/src/components/TheMap.vue
+++ b/example/src/components/TheMap.vue
@@ -9,17 +9,17 @@ const circleLayerParameters = [
   {
     radiusInMeters: 100,
     center: { lng: 139.7671, lat: 35.6812 },
-    fill: { red: 0.25, green: 0.25, blue: 0.5, alpha: 0.5 }
+    fill: { red: 0.5, green: 0.5, blue: 1.0, alpha: 0.5 }
   },
   {
     radiusInMeters: 250,
     center: { lng: 139.7671, lat: 35.6812 },
-    fill: { red: 0.5, green: 0.25, blue: 0.25, alpha: 0.3 }
+    fill: { red: 1.0, green: 0.5, blue: 0.5, alpha: 0.3 }
   },
   {
     radiusInMeters: 1000,
     center: { lng: 139.7671, lat: 35.6812 },
-    fill: { red: 0.25, green: 0.5, blue: 0.25, alpha: 0.75 }
+    fill: { red: 0.5, green: 1.0, blue: 0.5, alpha: 0.75 }
   }
 ]
 const circleLayer = new GeoCircleLayer('example-circle', circleLayerParameters[0])


### PR DESCRIPTION
Updates the example.
- Bumps `mapbox-geo-circle-layer` to v0.2.0
- Bumps example version to 0.2.0
- Cancels premultification of alphas